### PR TITLE
Add possibility to create graphs with duplicate nodes

### DIFF
--- a/pyyed/__init__.py
+++ b/pyyed/__init__.py
@@ -489,7 +489,7 @@ class Node:
         ET.SubElement(shape, "y:Shape", type=self.shape)
 
         if self.UML:
-            UML = ET.SubElement(shape, "y:UML")
+            UML = ET.SubElement(shape, "y:UML", use3DEffect="false")
 
             attributes = ET.SubElement(UML, "y:AttributeLabel", type=self.shape)
             attributes.text = self.UML["attributes"]


### PR DESCRIPTION
For some graphs, nodes can be duplicated because those nodes can represent the same entity in different namespace without it being an issue. 

For now, Pyyed doesn't allow such a feature. With in mind the fact that the default behavior of Pyyed must remain the same, I made some changes to the code to allow duplicates given specific options. Of course, a better design is possible if by default duplicates are allowed, but this is not my choice to make as I'm not the main developer of this package. 

To allow this, one has to define the graph with the allow_duplicates keyword. Then to add edges between those nodes, you need to use the add_edges_by_obj instead of the add_edges for the nodes that have duplicates because you don't have the node_id even if it's see, as it's automatic.

Here is an example to showcase how to do a graph with duplicate with the new code this branch proposes:
```python
import pyyed
g = pyyed.Graph(allow_duplicates=True)

pnode = g.add_node("parent")

n1 = g.add_node("child")
n2 = g.add_node("child")

g.add_edge_by_obj(pnode, n1)
g.add_edge_by_obj(pnode, n2)

g.write_graph("test.graphml", pretty_print=True)
```